### PR TITLE
ci: add npm provenance when publishing the package

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -51,6 +51,7 @@ jobs:
         run: npm ci --production
 
       - name: Publish to npm
-        run: npm publish --ignore-scripts --access public
+        run: |
+          npm publish --provenance --ignore-scripts --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_GUIDESMITHS }}


### PR DESCRIPTION
### Main changes

- :cloud: add npm provenance when publishing the package

### Additional notes

https://docs.npmjs.com/generating-provenance-statements

### Context

- :ticket: Closes #71 