### PR TITLE
fix: avoid generating error report when disableErrorReport is true

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -42,7 +42,7 @@ const scan = async (options) => {
   }
 
   if (forbiddenPackages.length) {
-    reporter.writeErrorReportFile(options.errorReportFileName, forbiddenPackages);
+    if (!options.disableErrorReport) reporter.writeErrorReportFile(options.errorReportFileName, forbiddenPackages);
     throw new Error(formatForbiddenLicenseError(forbiddenPackages));
   }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -8,6 +8,8 @@ const {
 } = require('./utils');
 
 const check = (license) => {
+  if (!license) throw new Error('Error: You must provide a license to check.');
+
   // @TODO Remove after issue has been solved
   if (isLicenseError(license)) {
     throw new Error(
@@ -24,6 +26,8 @@ const check = (license) => {
 
 const scan = async (options) => {
   const { failOn } = options;
+
+  if (!failOn) throw new Error('Error: You must provide a list of licenses to fail on in the "failOn" option.');
 
   checkLicenseError(failOn); // @TODO Remove after issue has been solved
   checkSPDXCompliance(failOn);

--- a/test/scan.test.js
+++ b/test/scan.test.js
@@ -46,7 +46,8 @@ describe('scan command', () => {
   describe('command execution output', () => {
     it('should call the checker passing the path to the working directory', async () => {
       const options = {
-        start: '/path/to/cwd'
+        start: '/path/to/cwd',
+        failOn: ['MIT']
       };
 
       const packages = {
@@ -67,7 +68,8 @@ describe('scan command', () => {
 
     it('should print a message if any of the packages\' licenses are not SPDX compliant', async () => {
       const options = {
-        start: '/path/to/cwd'
+        start: '/path/to/cwd',
+        failOn: ['MIT']
       };
 
       const packages = {
@@ -251,12 +253,36 @@ describe('scan command', () => {
         );
       }
     });
+
+    it('should not call the reporter to generate the error report file if the option "disableErrorReport" is supplied', async () => {
+      const options = {
+        start: '/path/to/cwd',
+        failOn: ['GPL-1.0+'],
+        disableErrorReport: true
+      };
+
+      const packages = {
+        'package-1': {
+          licenses: 'GPL-1.0',
+          repository: 'https://git.com/repo/repo',
+          path: '/path/to/package',
+          licenseFile: '/path/to/package/LICENSE'
+        }
+      };
+
+      parsePackages.mockResolvedValueOnce(packages);
+
+      await scan(options);
+
+      expect(writeErrorReportFile).not.toHaveBeenCalled();
+    });
   });
 
   describe('licenses report file', () => {
     it('should not call the reporter to generate the report file if the option "disableReport" is supplied', async () => {
       const options = {
         start: '/path/to/cwd',
+        failOn: ['MIT'],
         disableReport: true
       };
 
@@ -278,7 +304,8 @@ describe('scan command', () => {
 
     it('should call the reporter to generate the report file', async () => {
       const options = {
-        start: '/path/to/cwd'
+        start: '/path/to/cwd',
+        failOn: ['MIT']
       };
 
       const packages = {
@@ -300,6 +327,7 @@ describe('scan command', () => {
     it('should call the reporter with the right arguments', async () => {
       const options = {
         start: '/path/to/cwd',
+        failOn: ['MIT'],
         outputFileName: 'outputFileName',
         customHeader: 'customHeader'
       };

--- a/test/scan.test.js
+++ b/test/scan.test.js
@@ -254,7 +254,7 @@ describe('scan command', () => {
       }
     });
 
-    it('should not call the reporter to generate the error report file if the option "disableErrorReport" is supplied', async () => {
+    it('should not call the reporter to generate the error report file if the option "disableErrorReport" is enabled', async () => {
       const options = {
         start: '/path/to/cwd',
         failOn: ['GPL-1.0+'],
@@ -272,9 +272,15 @@ describe('scan command', () => {
 
       parsePackages.mockResolvedValueOnce(packages);
 
-      await scan(options);
-
-      expect(writeErrorReportFile).not.toHaveBeenCalled();
+      let error;
+      try {
+        await scan(options);
+      } catch (err) {
+        error = err;
+      } finally {
+        expect(error.message).toBe('Found 1 packages with licenses defined by the --failOn flag:\n > 1 packages with license GPL-1.0');
+        expect(writeErrorReportFile).not.toHaveBeenCalled();
+      }
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is an option in the library called `disableErrorReport` to disable generating the error report. However, even if the option is set to true, the report is generated when an error in the licenses is found.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes https://github.com/onebeyond/license-checker/issues/93

## Motivation and Context
Fix bug described in #93 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixed test that check that the error report is not generated when the `disableErrorReport` flag is true.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
