### PR TITLE
Feat/add allow only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,19 @@ node_modules/.bin/license-checker scan --failOn <license>
 
 #### 🚩 <a name="options"></a>Options
 
-| Option | Description | Requiered | Type | Default |
-|---|---|---|---|---|
-| --start | Path of the initial json to look for | false | string | `process.cwd()` |
-| --failOn | Fail (exit with code 1) if any package license does not satisfies any license in the provided list | true | string[] |  |
-| --outputFileName | Name of the report file generated | false | string | `license-report-<timestamp>.md` |
-| --errorReportFileName | Name of the error report file generated when a license in the `failOn` option is found | false | string | `license-error-<timestamp>.md` |
-| --disableErrorReport | Flag to disable the error report file generation | false | boolean  | `false` |
-| --disableReport | Flag to disable the report file generation, whether there is an error or not | false | boolean | `false` |
-| --customHeader | Name of a text file containing the custom header to add at the start of the generated report | false | string | This application makes use of the following open source packages: |
+| Option                | Description                                                                                                           | Requiered | Type | Default |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------|---|---|---|
+| --start               | Path of the initial json to look for                                                                                  | false | string | `process.cwd()` |
+| --failOn              | Fail (exit with code 1) if at least one package license **satisfies** one of the licenses in the provided list        | true | string[] |  |
+| --allowOnly           | Fail (exit with code 1) if at least one package license **does not satisfy** one of the licenses in the provided list | true | string[] |  |
+| --outputFileName      | Name of the report file generated                                                                                     | false | string | `license-report-<timestamp>.md` |
+| --errorReportFileName | Name of the error report file generated when a license in the `failOn` option is found                                | false | string | `license-error-<timestamp>.md` |
+| --disableErrorReport  | Flag to disable the error report file generation                                                                      | false | boolean  | `false` |
+| --disableReport       | Flag to disable the report file generation, whether there is an error or not                                          | false | boolean | `false` |
+| --customHeader        | Name of a text file containing the custom header to add at the start of the generated report                          | false | string | This application makes use of the following open source packages: |
+
+
+> ❗The options `--failOn` and `--allowOnly` are mutually exclusive. You must use one of them.
 
 ## 🧑‍💻 <a name="examples"></a>Examples
 
@@ -95,7 +99,7 @@ If the value provided is not SPDX compliant, the process fails (exit error 1).
 
 ### scan command
 
-All the values provided in the `failOn` list must be [SPDX](https://spdx.dev/specifications/) compliant. Otherwise, an error will be thrown (exit error 1). 
+All the values provided in the `failOn` or `allowOnly` list must be [SPDX](https://spdx.dev/specifications/) compliant. Otherwise, an error will be thrown (exit error 1). 
 Check the [SPDX license list](https://spdx.org/licenses/).
 
 ```sh
@@ -105,6 +109,22 @@ npx @onebeyond/license-checker scan --failOn MIT GPL-1.0+
 The input list is transformed into a SPDX expression with the `OR` logical operator. In the example, that is `MIT OR GPL-1.0+`.
 If any of the packages' licenses satisfies that expression, the process fails (exit error 1).
 
+SPDX compliance and `OR` input concatenation also apply for the `allowOnly` option:
+
+```sh
+npx @onebeyond/license-checker scan --allowOnly MIT GPL-1.0+
+```
+
+In this case, all the packages' licenses must be either `MIT` or `GPL-1.0+`.
+
+Arguments to `failOn` and `allowOnly` are not limited to one license. Expressions with logical operators are also accepted:
+
+```sh
+npx @onebeyond/license-checker scan --allowOnly "MIT AND Apache-2.0" GPL-1.0+
+```
+
+In this example, all the packages' licenses must be either `MIT AND Apache-2.0` **or** `GPL-1.0+`.
+
 ## 🔗 Useful links
 
 - [Licensing a repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/licensing-a-repository)
@@ -112,7 +132,7 @@ If any of the packages' licenses satisfies that expression, the process fails (e
 
 ## ⚠️ Temporal issue
 
-An issue in `spdx-satisfies` has been found and it's pending resolution. Until then, GFDL 1x licenses are not supported and an error will be thrown if either packages or failOn arguments contain it. 
+An issue in `spdx-satisfies` has been found, and it's pending resolution. Until then, GFDL 1x licenses are not supported and an error will be thrown if either packages or failOn arguments contain it. 
 
 ## Contributors ✨
 

--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,12 @@
 const yargs = require('yargs')(process.argv.slice(2));
+const { checkArgs } = require('./src/utils');
 
 // https://github.com/yargs/yargs/blob/main/docs/advanced.md#commanddirdirectory-opts
 module.exports = yargs
   .parserConfiguration({ 'camel-case-expansion': false })
   .commandDir('commands')
   .demandCommand()
+  .check(checkArgs)
   .help()
   .alias('help', 'h')
   .argv;

--- a/commands/scan.js
+++ b/commands/scan.js
@@ -19,9 +19,14 @@ exports.builder = {
     default: process.cwd()
   },
   failOn: {
-    description: 'fail (exit with code 1) if any package license does not satisfies any license in the provided list',
+    description: 'fail (exit with code 1) if at least one package license satisfies one of the licenses in the provided list ',
     type: 'array',
-    demandOption: true
+    conflicts: 'allowOnly'
+  },
+  allowOnly: {
+    description: 'fail (exit with code 1) if at least one package license does not satisfy one of the licenses in the provided list',
+    type: 'array',
+    conflicts: 'failOn'
   },
   outputFileName: {
     description: 'name of the output file generated',

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,6 +118,15 @@ const checkPackagesLicenses = (expression, packages) => {
   }, { forbidden: [], nonCompliant: [] });
 };
 
+const checkArgs = (args) => {
+  if (args._[0] === 'scan') {
+    const { failOn, allowOnly } = args;
+    if (!failOn && !allowOnly) throw new Error('You need to provide the "failOn" or "allowOnly" option.');
+    if ((failOn && !failOn.length) || (allowOnly && !allowOnly.length)) throw new Error('You need to provide at least one license.');
+  }
+  return true;
+};
+
 module.exports = {
   getPackageInfoList,
   formatForbiddenLicenseError,
@@ -125,5 +134,6 @@ module.exports = {
   checkSPDXCompliance,
   checkPackagesLicenses,
   isLicenseError,
-  checkLicenseError
+  checkLicenseError,
+  checkArgs
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,7 +41,7 @@ const formatForbiddenLicenseError = licenses => {
       [licenses]: !stats[licenses] ? 1 : stats[licenses] + 1
     }), {});
 
-  const header = `Found ${licenses.length} packages with licenses defined by the --failOn flag:`;
+  const header = `Found ${licenses.length} packages with licenses defined by the provided option:`;
   const lines = Object
     .entries(forbiddenLicenseStats)
     .map(([license, value]) => ` > ${value} packages with license ${license}`)
@@ -66,7 +66,7 @@ const checkSPDXCompliance = (licenses = []) => {
   const invalidLicenses = licenses.filter(arg => !isSPDXCompliant(arg));
   if (invalidLicenses.length) {
     throw new Error(
-      `The following licenses are not SPDX compliant. Please, use the --checkLicense option to validate your input:\n${invalidLicenses.join(' | ')}`
+      `The following licenses are not SPDX compliant. Please, use the "check" command to validate your input:\n${invalidLicenses.join(' | ')}`
     );
   }
 };
@@ -80,7 +80,7 @@ const checkLicenseError = (licenses = []) => {
   const errorLicenses = licenses.some(isLicenseError);
   if (errorLicenses) {
     throw new Error(
-      'Your failOn list contains a GFDL-1.x licenses and they are temporary unallowed. There\'s an issue pending to solve.'
+      'Your licenses list contains a GFDL-1.x licenses and they are temporary unallowed. There\'s an issue pending to solve.'
     );
   }
 };

--- a/test/scan.test.js
+++ b/test/scan.test.js
@@ -23,7 +23,7 @@ describe('scan command', () => {
       } catch (e) {
         error = e;
       } finally {
-        expect(error.message).toBe('The following licenses are not SPDX compliant. Please, use the check command to validate your input:\nGPL | BSD');
+        expect(error.message).toBe('The following licenses are not SPDX compliant. Please, use the "check" command to validate your input:\nGPL | BSD');
       }
     });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,59 @@
+const { checkArgs } = require('../src/utils');
+
+describe('Utilities', () => {
+  describe('checkArgs', () => {
+    describe('when the command is "scan"', () => {
+      it('should return true when the "_" property is not "scan"', () => {
+        const args = { _: ['foo'] };
+
+        let error;
+        try {
+          checkArgs(args);
+        } catch (e) {
+          error = e;
+        } finally {
+          expect(error).toBeUndefined();
+        }
+      });
+
+      it('should throw an error if both "failOn" and "allowOnly" are missing when the "_" property is "scan"', () => {
+        const args = { _: ['scan'], foo: 'bar' };
+
+        let error;
+        try {
+          checkArgs(args);
+        } catch (e) {
+          error = e;
+        } finally {
+          expect(error.message).toBe('You need to provide the "failOn" or "allowOnly" option.');
+        }
+      });
+
+      it('should throw an error if the "failOn" is an empty array when the "_" property is "scan"', () => {
+        const args = { _: ['scan'], failOn: [] };
+
+        let error;
+        try {
+          checkArgs(args);
+        } catch (e) {
+          error = e;
+        } finally {
+          expect(error.message).toBe('You need to provide at least one license.');
+        }
+      });
+
+      it('should throw an error if the "allowOnly" is an empty array when the "_" property is "scan"', () => {
+        const args = { _: ['scan'], allowOnly: [] };
+
+        let error;
+        try {
+          checkArgs(args);
+        } catch (e) {
+          error = e;
+        } finally {
+          expect(error.message).toBe('You need to provide at least one license.');
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
- Add `allowOnly` option to allow only package licenses complying with the provided list
- Add a function to check `scan` inputs
- Update error messages 

## Related Issue
#24 

## Motivation and Context
Users may want to be more strict with the licenses of the packages in their projects. By using `allowOnly`, they can make sure only packages with certain licenses are allowed. 

To achieve the same behaviour with the `failOn` option, they would need to provide all the SPDX licenses available except the ones they'd like to be banned. With `allowOnly`, they just need to supply the licenses they need their packages to comply with.

## How Has This Been Tested?
I've added tests for the `checkArgs` util and `scan` use cases with `allowOnly`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
